### PR TITLE
Add GitHub Skills activity to fix Issue #6

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub Certifications program",
+        "schedule": "Wednesdays, 3:00 PM - 4:00 PM",
+        "max_participants": 20,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
This PR adds the missing "GitHub Skills" activity to the school activities signup page, as requested in Issue #6. The activity includes a description about learning coding and collaboration skills through GitHub Certifications, with a schedule on Wednesdays.